### PR TITLE
README.md Serial Port Fix

### DIFF
--- a/nucleus_driver/README.md
+++ b/nucleus_driver/README.md
@@ -27,7 +27,7 @@ The nucleus device supports both serial and TCP connection. For serial connectio
 thus only the serial port is required to establish a connection with the driver
 
 ```python
-SERIAL_PORT = "dev/ttyUSB0"
+SERIAL_PORT = "/dev/ttyUSB0"
 
 driver.set_serial_configuration(port=SERIAL_PORT)
 driver.connect(connection_type='serial')


### PR DESCRIPTION
When I attempted to integrate the driver with the steps in README.md, I was mostly successful, but ran into errors when I listed the port as "dev/ttyUSB0." When I did so, I received the error message "EXCEPTION: Failed to connect through serial: [Errno 2] No such file or directory: 'dev/ttyUSB0'.

I've made this change in README.md and otherwise left things in their original form.
